### PR TITLE
Add support for `swift-bsp`

### DIFF
--- a/lua/bsp-config/server_configurations/swift-bsp.lua
+++ b/lua/bsp-config/server_configurations/swift-bsp.lua
@@ -1,0 +1,15 @@
+return {
+  on_create_config = function (server_install_dir, workspace_dir)
+      local connection_details = {
+        name = 'swift-bsp',
+        bspVersion = '2.2.0',
+        languages = { 'swift' },
+        argv = {
+            "swift-bsp"
+        }
+      }
+
+      require("bsp").writeConnectionDetails(connection_details, workspace_dir .. "/buildServer.json")
+    end
+}
+

--- a/lua/bsp.lua
+++ b/lua/bsp.lua
@@ -67,6 +67,16 @@ local default_config = {
       return false
     end,
 
+    ['swift-bsp'] = function(workspace_dir, connection_details)
+        for name, type in vim.fs.dir(workspace_dir) do
+            if (type == 'file') and name:match("^buildServer.json$") then
+                return true
+            end
+        end
+
+        return false
+    end,
+
     ['*'] = function (workspace_dir, connection_details)
       -- .bsp/*.json
       for name, type in vim.fs.dir(workspace_dir .. "/.bsp/") do
@@ -353,6 +363,15 @@ function bsp.findConnectionDetails ()
       end
     end
   end
+
+  -- swift-bsp expects a `buildServer.json` in the root of the repository.
+  local buildServerFile = vim.fn.expand("buildServer.json")
+  if vim.uv.fs_stat(buildServerFile) then
+      local json = vim.fn.join(vim.fn.readfile(buildServerFile), '\n')
+      local config = vim.json.decode(json)
+      configs[buildServerFile] = config
+  end
+
   return configs
 end
 

--- a/lua/bsp/protocol/init.lua
+++ b/lua/bsp/protocol/init.lua
@@ -10,7 +10,8 @@ local protocol = {}
         'csharp',
         'rust',
         'scala',
-        'kotlin'
+        'kotlin',
+        'swift'
       }
     }
   end

--- a/plugin/bsp.lua
+++ b/plugin/bsp.lua
@@ -93,7 +93,7 @@ cmd('BspCreateConfig',
     desc = 'Create new configuration for specified BSP server in current directory',
     nargs = '?',
     complete = function ()
-      return { "dotnet-bsp", "cargo-bsp", "gradle-bsp" }
+      return { "dotnet-bsp", "cargo-bsp", "gradle-bsp", "swift-bsp" }
     end
   }
 )


### PR DESCRIPTION
This adds support for [`swift-bsp`](https://github.com/wvteijlingen/swift-bsp), currently `swift-bsp` doesn't support a lot of BSP actions, so this is more about hooking everything up for further investigations.
